### PR TITLE
Revert "Make LOVABLE_WEBHOOK_URL optional in sync workflows"

### DIFF
--- a/.github/workflows/sync-file-changes-to-lovable.yml
+++ b/.github/workflows/sync-file-changes-to-lovable.yml
@@ -3,9 +3,8 @@
 # Lovable: https://lovable.dev/projects/657fb572-13a5-4a3e-bac9-184d39fdf7e6
 #
 # On every push, sends lists of added/modified/removed files to Lovable via webhook.
-# SETUP (OPTIONAL): In GitHub repo → Settings → Secrets and variables → Actions, add:
+# SETUP: In GitHub repo → Settings → Secrets and variables → Actions, add:
 #   LOVABLE_WEBHOOK_URL = (webhook URL from Lovable for file sync)
-#   If not set, the workflow will succeed with a warning message.
 #
 name: Sync File Changes to Lovable
 
@@ -22,12 +21,11 @@ jobs:
         env:
           LOVABLE_WEBHOOK_URL: ${{ secrets.LOVABLE_WEBHOOK_URL }}
         run: |
-          # Check if LOVABLE_WEBHOOK_URL is set
+          # Validate that LOVABLE_WEBHOOK_URL is set
           if [ -z "$LOVABLE_WEBHOOK_URL" ]; then
-            echo "⚠️  Warning: LOVABLE_WEBHOOK_URL is not set"
-            echo "ℹ️  To enable sync with Lovable, set the LOVABLE_WEBHOOK_URL secret in repository settings."
-            echo "✓ Workflow will continue without syncing."
-            exit 0
+            echo "Error: LOVABLE_WEBHOOK_URL is not set"
+            echo "Please set the LOVABLE_WEBHOOK_URL secret in the repository settings to enable sync."
+            exit 1
           fi
 
           # Debug: Show masked URL (only show protocol and domain)
@@ -36,10 +34,9 @@ jobs:
 
           # Validate URL format
           if ! echo "$LOVABLE_WEBHOOK_URL" | grep -qE '^https?://'; then
-            echo "⚠️  Warning: LOVABLE_WEBHOOK_URL does not appear to be a valid URL"
+            echo "Error: LOVABLE_WEBHOOK_URL does not appear to be a valid URL"
             echo "Expected format: https://api.lovable.ai/... or similar"
-            echo "✓ Workflow will continue without syncing."
-            exit 0
+            exit 1
           fi
 
           echo "Gathering lists of changed files..."

--- a/.github/workflows/sync-issues-prs-to-lovable.yml
+++ b/.github/workflows/sync-issues-prs-to-lovable.yml
@@ -3,9 +3,8 @@
 # Lovable: https://lovable.dev/projects/657fb572-13a5-4a3e-bac9-184d39fdf7e6
 #
 # Sends issue/PR open, edit, reopen, close events to Lovable via webhook.
-# SETUP (OPTIONAL): In GitHub repo → Settings → Secrets and variables → Actions, add:
+# SETUP: In GitHub repo → Settings → Secrets and variables → Actions, add:
 #   LOVABLE_WEBHOOK_URL = (webhook URL from Lovable, if provided)
-#   If not set, the workflow will succeed with a warning message.
 #
 name: Sync Issues and PRs to Lovable
 
@@ -23,12 +22,11 @@ jobs:
         env:
           LOVABLE_WEBHOOK_URL: ${{ secrets.LOVABLE_WEBHOOK_URL }}
         run: |
-          # Check if LOVABLE_WEBHOOK_URL is set
+          # Validate that LOVABLE_WEBHOOK_URL is set
           if [ -z "$LOVABLE_WEBHOOK_URL" ]; then
-            echo "⚠️  Warning: LOVABLE_WEBHOOK_URL is not set"
-            echo "ℹ️  To enable sync with Lovable, set the LOVABLE_WEBHOOK_URL secret in repository settings."
-            echo "✓ Workflow will continue without syncing."
-            exit 0
+            echo "Error: LOVABLE_WEBHOOK_URL is not set"
+            echo "Please set the LOVABLE_WEBHOOK_URL secret in the repository settings to enable sync."
+            exit 1
           fi
 
           # Debug: Show masked URL (only show protocol and domain)
@@ -37,10 +35,9 @@ jobs:
 
           # Validate URL format
           if ! echo "$LOVABLE_WEBHOOK_URL" | grep -qE '^https?://'; then
-            echo "⚠️  Warning: LOVABLE_WEBHOOK_URL does not appear to be a valid URL"
+            echo "Error: LOVABLE_WEBHOOK_URL does not appear to be a valid URL"
             echo "Expected format: https://api.lovable.ai/... or similar"
-            echo "✓ Workflow will continue without syncing."
-            exit 0
+            exit 1
           fi
 
           echo "Sending event to Lovable..."

--- a/docs/DEPLOYMENT_TEMPLATE.md
+++ b/docs/DEPLOYMENT_TEMPLATE.md
@@ -183,7 +183,7 @@ git push origin main
 Ensure these are configured in GitHub repository settings:
 
 #### Lovable Integration
-- `LOVABLE_WEBHOOK_URL` - (Optional) For file change synchronization with Lovable
+- `LOVABLE_WEBHOOK_URL` - For file change synchronization
 - Lovable project URL: https://lovable.dev/projects/657fb572-13a5-4a3e-bac9-184d39fdf7e6
 
 #### Optional Notifications


### PR DESCRIPTION
Reverts asperpharma/understand-project#50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * LOVABLE_WEBHOOK_URL configuration is now required instead of optional for file synchronization.
  * Workflows now fail with an error if the configuration is missing or invalid, instead of continuing with a warning.

* **Documentation**
  * Updated setup documentation to reflect that LOVABLE_WEBHOOK_URL is a required configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->