### PR TITLE
fix: add wrangler.toml for Cloudflare Workers static assets deployment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,9 @@
+name = "asper-beauty-shop"
+compatibility_date = "2024-09-23"
+compatibility_flags = ["nodejs_compat"]
+
+[build]
+command = "npm run build"
+
+[assets]
+directory = "./dist"


### PR DESCRIPTION
Configures the asper-beauty-shop Cloudflare Worker to build with npm run build and serve the Vite dist/ output as static assets.

https://claude.ai/code/session_01XEJKNMnMCkGQwqKZPe3gNh